### PR TITLE
fix(docstrings): escape chars in sample ini files to allow code introspection

### DIFF
--- a/profile_manager/handlers/customization.py
+++ b/profile_manager/handlers/customization.py
@@ -13,7 +13,7 @@ def import_customizations(source_profile_path: Path, target_profile_path: Path):
     E.g.
     [Customization]
     Browser=true
-    Browser\AFS=false
+    Browser\\AFS=false
     ...
 
     Args:

--- a/profile_manager/handlers/expressions.py
+++ b/profile_manager/handlers/expressions.py
@@ -9,8 +9,8 @@ def import_expressions(source_qgis_ini_file: Path, target_qgis_ini_file: Path):
     ...
     [expressions]
     ...
-    user\test_expression\expression=1 + 1
-    user\test_expression\helpText="..."
+    user\\test_expression\\expression=1 + 1
+    user\\test_expression\\helpText="..."
     ...
 
     Note: This does not handle Python expression functions yet. TODO


### PR DESCRIPTION
Spotted by migration script to PyQt6 https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6/